### PR TITLE
Minor docstring updates

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "UnPack"
 uuid = "3a884ed6-31ef-47d7-9d2a-63182c4928ed"
 authors = ["Mauro Werder"]
-version = "1.0.0"
+version = "1.0.1"
 
 [compat]
 julia = "1"

--- a/src/UnPack.jl
+++ b/src/UnPack.jl
@@ -63,11 +63,11 @@ function pack! end
 @inline pack!(x::AbstractDict{<:AbstractString}, ::Val{k}, val) where {k} = x[string(k)]=val
 
 """
-Unpacks fields/properties/keys from a composite type, a `Dict{Symbol}`, a `Dict{String}`,
-or a module into variables
 ```julia_skip
-@unpack a, b, c = dict_or_typeinstance
+@unpack a, b, c, ... = dict_or_typeinstance
 ```
+Unpack fields/properties/keys from a composite type, a `Dict{Symbol}`, a `Dict{String}`,
+or a module into variables.
 
 Example with dict:
 ```julia
@@ -106,10 +106,10 @@ end
 
 
 """
-Packs variables into a mutable, composite type, a `Dict{Symbol}`, or a `Dict{String}`
 ```julia_skip
-@pack! dict_or_typeinstance = a, b, c
+@pack! dict_or_typeinstance = a, b, c, ...
 ```
+Pack variables into a mutable composite type, a `Dict{Symbol}`, or a `Dict{String}`.
 
 Example with dict:
 ```julia
@@ -131,7 +131,7 @@ d.a == 99 #true
 d.c == "HaHa" #true
 ```
 
-Note that its functionality can be extende by adding methods to the
+Note that its functionality can be extended by adding methods to the
 `UnPack.pack!` function.
 
 To "pack" immutables use the package Setfield.jl.


### PR DESCRIPTION
Here I am changing the docstrings in two ways:

* Typo stuff
* Aligning more with Julia recommeded style: call signature is shown first and the docstring is in imperative "do this" versus "does that".

cf https://github.com/JuliaDynamics/DrWatson.jl/pull/148