### PR TITLE
fix memory leak when unpacking at top-level scope

### DIFF
--- a/src/UnPack.jl
+++ b/src/UnPack.jl
@@ -97,7 +97,7 @@ macro unpack(args)
     kd = [:( $key = $UnPack.unpack($suitecase_instance, Val{$(Expr(:quote, key))}()) ) for key in items]
     kdblock = Expr(:block, kd...)
     expr = quote
-        $suitecase_instance = $suitecase # handles if suitecase is not a variable but an expression
+        local $suitecase_instance = $suitecase # handles if suitecase is not a variable but an expression
         $kdblock
         $suitecase_instance # return RHS of `=` as standard in Julia
     end
@@ -148,7 +148,7 @@ function _pack_bang(args)
     kd = [:( $UnPack.pack!($suitecase_instance, Val{$(Expr(:quote, key))}(), $key) ) for key in items]
     kdblock = Expr(:block, kd...)
     return quote
-        $suitecase_instance = $suitecase # handles if suitecase is not a variable but an expression
+        local $suitecase_instance = $suitecase # handles if suitecase is not a variable but an expression
         $kdblock
         ($(items...),)
     end


### PR DESCRIPTION
The current macro expands `@unpack x = foo()` to 

```
var### = foo()
begin
    x = unpack(var###, Val{:x})
end
var###
```

where `var###` is a new `gensym`ed name each time, but if you ever do `@unpack` from the REPL / IJulia, then all the `var###` are in `Main` forever, thus leaking memory. 

This makes it so we expand to

```
local x
let var### = foo()
    begin
        x = unpack(var###, Val{:x})
    end
    var###
end
```

where the `local` is needed to make sure scoping is always right. 