### PR TITLE
Add support for renamed local variables.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,8 +10,8 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.6'
-          - '1'
+          - '1.0'               # lowest supported version
+          - '1'                 # latest release
           - 'nightly'
         os:
           - ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,8 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.0'
+          - '1.6'
+          - '1'
           - 'nightly'
         os:
           - ubuntu-latest

--- a/Project.toml
+++ b/Project.toml
@@ -4,7 +4,7 @@ authors = ["Mauro Werder"]
 version = "1.0.2"
 
 [compat]
-julia = "1.6"
+julia = "1"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/Project.toml
+++ b/Project.toml
@@ -4,7 +4,7 @@ authors = ["Mauro Werder"]
 version = "1.0.2"
 
 [compat]
-julia = "1"
+julia = "1.6"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/README.md
+++ b/README.md
@@ -49,6 +49,20 @@ d = Dict{String,Any}()
 d # -> Dict{String,Any}("a"=>5.0,"c"=>"Hi!")
 ```
 
+Using `=>` allows unpacking to local variables that are different from a key:
+```julia
+struct MyContainer{T}
+    a::T
+    b::T
+end
+
+function Base.:(==)(x::MyContainer, y::MyContainer)
+    @unpack a, b = x
+    @unpack a => ay, b => by = y
+    a == ay && b ≈ by
+end
+```
+
 ## Customization of `@unpack` and `@pack!`
 
 What happens during the (un-)packing of a particular datatype is

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -37,10 +37,12 @@ using Test
     end
 
     @testset "invalid patterns" begin
-        @test_throws ErrorException macroexpand(Main, :(@unpack a))
-        @test_throws ErrorException macroexpand(Main, :(@unpack "a fish" = 1))
-        @test_throws ErrorException macroexpand(Main, :(@unpack a => "a fish" = 1))
-        @test_throws ErrorException macroexpand(Main, :(@unpack 1 => b = 1))
+        # NOTE: before 1.8, error in macroexpand throws LoadError
+        ERR = VERSION < v"1.8" ? LoadError : ErrorException
+        @test_throws ERR macroexpand(Main, :(@unpack a))
+        @test_throws ERR macroexpand(Main, :(@unpack "a fish" = 1))
+        @test_throws ERR macroexpand(Main, :(@unpack a => "a fish" = 1))
+        @test_throws ERR macroexpand(Main, :(@unpack 1 => b = 1))
     end
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -6,22 +6,42 @@ using Test
     ###########################
     # Packing and unpacking @unpack, @pack!
     ##########################
-    # Example with dict:
-    d = Dict{Symbol,Any}(:a=>5.0,:b=>2,:c=>"Hi!")
-    @unpack a, c = d
-    @test a == 5.0 #true
-    @test c == "Hi!" #true
 
-    d = Dict("a"=>5.0,"b"=>2,"c"=>"Hi!")
-    @unpack a, c = d
-    @test a == 5.0 #true
-    @test c == "Hi!" #true
+    @testset "dict with symbols" begin
+        d = Dict{Symbol,Any}(:a=>5.0,:b=>2,:c=>"Hi!")
+        @unpack a, c = d
+        @test a == 5.0 #true
+        @test c == "Hi!" #true
+    end
 
-    # Example with named tuple
-    @eval d = (a=5.0, b=2, c="Hi!")
-    @unpack a, c = d
-    @test a == 5.0 #true
-    @test c == "Hi!" #true
+    @testset "dict with strings" begin
+        d = Dict("a"=>5.0,"b"=>2,"c"=>"Hi!")
+        @unpack a, c = d
+        @test a == 5.0 #true
+        @test c == "Hi!" #true
+    end
+
+    @testset "named tuple" begin
+        @eval d = (a=5.0, b=2, c="Hi!")
+        @unpack a, c = d
+        @test a == 5.0 #true
+        @test c == "Hi!" #true
+    end
+
+    @testset "named tuple, renaming"  begin
+        d = (a = 1, b = 2)
+        @unpack a => c, b = d
+        @test c == 1
+        @test b == 2
+        @test !@isdefined a
+    end
+
+    @testset "invalid patterns" begin
+        @test_throws ErrorException macroexpand(Main, :(@unpack a))
+        @test_throws ErrorException macroexpand(Main, :(@unpack "a fish" = 1))
+        @test_throws ErrorException macroexpand(Main, :(@unpack a => "a fish" = 1))
+        @test_throws ErrorException macroexpand(Main, :(@unpack 1 => b = 1))
+    end
 end
 
 # having struct-defs inside a testset seems to be problematic in some julia version


### PR DESCRIPTION
Fixes #18.

Incidental changes:

- wrap some tests into testsets, so that we can use `@isdefined` in tests

- add more validation of input expressions, test for expressions that are invalid but were expanded and failed with an obscure error message